### PR TITLE
Fix module-level name storage in VM globals

### DIFF
--- a/paopao/hython/VM.hx
+++ b/paopao/hython/VM.hx
@@ -176,7 +176,12 @@ class VM {
 
 			case STORE_NAME(name):
 				var v = pop();
-				frame.locals.set(name, v);
+				// At module scope, names should be visible as globals so
+				// host code can fetch them via getGlobal().
+				if (frame.code.name == "<module>")
+					globals.set(name, v);
+				else
+					frame.locals.set(name, v);
 
 			case LOAD_FAST(name):
 				if (!frame.locals.exists(name))


### PR DESCRIPTION
## Summary
- fixed `STORE_NAME` in `paopao/hython/VM.hx` to write into `globals` when executing module code (`<module>`)
- kept function/local behavior unchanged by continuing to store into `frame.locals` outside module scope

## Why
`tests/TestMain.hx` expects module assignment (`result = add(2, 3)`) to be retrievable through `vm.getGlobal("result")`. Previously, `STORE_NAME` always wrote to `frame.locals`, so `getGlobal` returned `VNone`.

## Impact
- module-level variables are now visible via `VM.getGlobal()`
- host integrations that read script outputs from globals work as expected

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3ea4fae0832ab5bb827b97d567a2)