### PR TITLE
Fix float-int subtraction behavior in VM and add regression test

### DIFF
--- a/paopao/hython/VM.hx
+++ b/paopao/hython/VM.hx
@@ -429,7 +429,7 @@ class VM {
 			case [VInt(a), VInt(b)]: VInt(a - b);
 			case [VFloat(a), VFloat(b)]: VFloat(a - b);
 			case [VInt(a), VFloat(b)]: VFloat(a - b);
-			case [VFloat(a), VInt(b)]: VFloat(a + b);
+			case [VFloat(a), VInt(b)]: VFloat(a - b);
 			default: throw new Error(TypeError('unsupported operand types for -'), 0, 0);
 		}
 	}

--- a/tests/TestMain.hx
+++ b/tests/TestMain.hx
@@ -1,22 +1,15 @@
 package;
 
-import paopao.hython.*;
+import tests.unit.TestRunner;
+import tests.unit.VMArithmeticTest;
 
 class TestMain {
-    static function main() {
-        var source = "def add(x, y):\n  return x + y\n\nresult = add(2, 3)";
-        try {
-            var vm = new VM();
-            var ast = new Lexer(source).tokenize();
-            var code = new Parser(ast).parse();
-            new Semantic().analyze(code);
-            var bytes = new Compiler().compile(code);
-            
-            vm.execute(bytes);
-            var result = vm.getGlobal("result");
-            @:privateAccess trace("Result: " + vm.valueToString(result));  // "Result: 5"
-        } catch (error:Dynamic) {
-            trace("Error: " + error);
-        }
-    }
+	static function main() {
+		var runner = new TestRunner();
+		runner.add(new VMArithmeticTest());
+
+		if (!runner.run()) {
+			Sys.exit(1);
+		}
+	}
 }

--- a/tests/unit/VMArithmeticTest.hx
+++ b/tests/unit/VMArithmeticTest.hx
@@ -1,0 +1,29 @@
+package tests.unit;
+
+import paopao.hython.Compiler;
+import paopao.hython.Lexer;
+import paopao.hython.Parser;
+import paopao.hython.Semantic;
+import paopao.hython.VM;
+import tests.unit.TestCase;
+
+class VMArithmeticTest extends TestCase {
+	public function new() {
+		super();
+	}
+
+	public function testFloatMinusIntUsesSubtraction():Void {
+		var vm = executeSource("result = 5.5 - 2");
+		assertEquals(3.5, vm.toHaxe(vm.getGlobal("result")));
+	}
+
+	private function executeSource(source:String):VM {
+		var vm = new VM();
+		var tokens = new Lexer(source).tokenize();
+		var program = new Parser(tokens).parse();
+		new Semantic().analyze(program);
+		var code = new Compiler().compile(program);
+		vm.execute(code);
+		return vm;
+	}
+}


### PR DESCRIPTION
### Motivation
- A logic bug in the VM caused `VFloat - VInt` to perform addition instead of subtraction, corrupting arithmetic results for mixed-type operands. 
- Correct numeric behavior for core binary ops is essential for program correctness across the runtime and compiler pipeline. 
- Add a regression test and use the unit test harness so the issue is prevented from regressing.

### Description
- Fix `binOpSub` in `paopao/hython/VM.hx` so the `case [VFloat(a), VInt(b)]` returns `VFloat(a - b)` instead of performing `a + b`.
- Add `tests/unit/VMArithmeticTest.hx` with `testFloatMinusIntUsesSubtraction` that compiles and runs `result = 5.5 - 2` through Lexer→Parser→Semantic→Compiler→VM and asserts the result is `3.5`.
- Update `tests/TestMain.hx` to wire the `TestRunner` and exit with non-zero status on failures so CI can detect test failures.

### Testing
- Added a focused unit test (`tests/unit/VMArithmeticTest.hx`) but the test suite could not be executed in this environment because `haxe` is not installed, so runtime execution was not performed.
- Performed repository cleanliness checks to ensure the patch is syntactically integrated and the test runner wiring is present.
- The change is localized to the VM arithmetic path and the new test exercises the specific regression, ready for CI to run when Haxe is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4563b3d0832a9b558361e3da1092)