### PR TITLE
test: expand VM arithmetic coverage

### DIFF
--- a/tests/unit/VMArithmeticTest.hx
+++ b/tests/unit/VMArithmeticTest.hx
@@ -17,6 +17,26 @@ class VMArithmeticTest extends TestCase {
 		assertEquals(3.5, vm.toHaxe(vm.getGlobal("result")));
 	}
 
+	public function testIntPlusFloatProducesFloat():Void {
+		var vm = executeSource("result = 2 + 3.5");
+		assertEquals(5.5, vm.toHaxe(vm.getGlobal("result")));
+	}
+
+	public function testMultiplicationHasHigherPrecedenceThanAddition():Void {
+		var vm = executeSource("result = 2 + 3 * 4");
+		assertEquals(14, vm.toHaxe(vm.getGlobal("result")));
+	}
+
+	public function testParenthesesOverrideDefaultPrecedence():Void {
+		var vm = executeSource("result = (2 + 3) * 4");
+		assertEquals(20, vm.toHaxe(vm.getGlobal("result")));
+	}
+
+	public function testIntegerDivisionReturnsFloat():Void {
+		var vm = executeSource("result = 7 / 2");
+		assertEquals(3.5, vm.toHaxe(vm.getGlobal("result")));
+	}
+
 	private function executeSource(source:String):VM {
 		var vm = new VM();
 		var tokens = new Lexer(source).tokenize();


### PR DESCRIPTION
### Motivation
- Increase VM arithmetic test coverage for mixed integer/float behavior and operator precedence to catch regressions in numeric operations.
- Verify that parsing/compilation/VM pipeline (`Lexer` → `Parser` → `Semantic` → `Compiler` → `VM`) yields correct runtime results for common arithmetic expressions.

### Description
- Added four new tests to `tests/unit/VMArithmeticTest.hx`: `testIntPlusFloatProducesFloat`, `testMultiplicationHasHigherPrecedenceThanAddition`, `testParenthesesOverrideDefaultPrecedence`, and `testIntegerDivisionReturnsFloat`.
- Each test exercises end-to-end execution by using the existing `executeSource` helper that tokenizes, parses, semantically analyzes, compiles, and runs the snippet on the `VM`.
- No changes were made to production code or helpers; only the test file `tests/unit/VMArithmeticTest.hx` was modified and committed with message `test: expand VM arithmetic coverage`.

### Testing
- Attempted to run the test suite with `haxe test.hxml && ./bin/test/cpp/TestMain`, but execution failed in this environment because `haxe` is not installed, so the tests were not executed here.
- The test file was compiled into the repository and committed successfully, but automated test execution remains unverified until `haxe` is available in the CI/runtime environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed57b182fc832a99357bcd284e54cb)