### PR TITLE
Add source-positioned semantic errors with filename plumbing

### DIFF
--- a/paopao/hython/Ast.hx
+++ b/paopao/hython/Ast.hx
@@ -5,6 +5,14 @@
 package paopao.hython;
 
 import paopao.hython.utils.Int8; // Retained for enum backing types where needed
+import haxe.ds.ObjectMap;
+
+typedef SourcePos = {
+	var line:Int;
+	var col:Int;
+	var ?colStart:Int;
+	var ?colEnd:Int;
+}
 
 // Root Module
 // Represents a full Python module (a file).
@@ -181,5 +189,28 @@ class ExceptHandler {
 		this.type = type;
 		this.name = name;
 		this.body = body;
+	}
+}
+
+class NodeMeta {
+	private static var stmtPositions:ObjectMap<Dynamic, SourcePos> = new ObjectMap();
+	private static var exprPositions:ObjectMap<Dynamic, SourcePos> = new ObjectMap();
+
+	public static function setStmtPos(stmt:Stmt, pos:SourcePos):Stmt {
+		stmtPositions.set(cast stmt, pos);
+		return stmt;
+	}
+
+	public static function setExprPos(expr:Expr, pos:SourcePos):Expr {
+		exprPositions.set(cast expr, pos);
+		return expr;
+	}
+
+	public static function getStmtPos(stmt:Stmt):Null<SourcePos> {
+		return stmtPositions.get(cast stmt);
+	}
+
+	public static function getExprPos(expr:Expr):Null<SourcePos> {
+		return exprPositions.get(cast expr);
 	}
 }

--- a/paopao/hython/Lexer.hx
+++ b/paopao/hython/Lexer.hx
@@ -74,23 +74,27 @@ enum Token {
 class Lexer {
 	public var source:String;
 	public var tokens:Array<Token>;
+	public var tokenPositions:Array<TokenPos>;
 	public var pos:Int;
 	public var line:Int;
 	public var col:Int;
 
 	private var indentStack:Array<Int>;
 	private var pendingTokens:Array<Token>;
+	private var pendingTokenPositions:Array<TokenPos>;
 	private var atLineStart:Bool;
 
 	public function new(source:String) {
 		this.source = source;
 		this.tokens = [];
+		this.tokenPositions = [];
 		this.pos = 0;
 		this.line = 1;
 		this.col = 1;
 
 		this.indentStack = [0];
 		this.pendingTokens = [];
+		this.pendingTokenPositions = [];
 		this.atLineStart = true;
 	}
 
@@ -98,11 +102,14 @@ class Lexer {
 		while (true) {
 			var token = nextToken();
 			tokens.push(token);
+			tokenPositions.push(lastTokenPos);
 			if (token == TEOF)
 				break;
 		}
 		return tokens;
 	}
+
+	public var lastTokenPos(default, null):TokenPos;
 
 	// Helpers zone functions for peeking, advancing, and character classification
 
@@ -179,6 +186,7 @@ class Lexer {
 		if (count > current) {
 			indentStack.push(count);
 			pendingTokens.push(TIndent);
+			pendingTokenPositions.push(makePos(line, col));
 		} else if (count < current) {
 			while (indentStack[indentStack.length - 1] != count) {
 				if (indentStack.length <= 1) {
@@ -186,6 +194,7 @@ class Lexer {
 				}
 				indentStack.pop();
 				pendingTokens.push(TDedent);
+				pendingTokenPositions.push(makePos(line, col));
 			}
 		}
 	}
@@ -269,14 +278,17 @@ class Lexer {
 
 	public function nextToken():Token {
 		if (pendingTokens.length > 0) {
+			lastTokenPos = pendingTokenPositions.shift();
 			return pendingTokens.shift();
 		}
 
 		if (atLineStart) {
 			atLineStart = false;
 			processIndentation();
-			if (pendingTokens.length > 0)
+			if (pendingTokens.length > 0) {
+				lastTokenPos = pendingTokenPositions.shift();
 				return pendingTokens.shift();
+			}
 		}
 
 		skipWhitespace();
@@ -284,45 +296,66 @@ class Lexer {
 		if (pos >= source.length) {
 			if (indentStack.length > 1) {
 				indentStack.pop();
+				lastTokenPos = makePos(line, col);
 				return TDedent;
 			}
+			lastTokenPos = makePos(line, col);
 			return TEOF;
 		}
 
 		var ch = peek();
+		var startLine = line;
+		var startCol = col;
 
 		if (ch == "\n") {
 			advance();
 			atLineStart = true;
+			lastTokenPos = makePos(startLine, startCol);
 			return TNewline;
 		}
 
-		if (ch == '"' || ch == "'")
-			return readString(ch);
-		if (isDigit(ch))
-			return readNumber();
-		if (isAlpha(ch))
-			return readIdentifier();
+		if (ch == '"' || ch == "'") {
+			var t = readString(ch);
+			lastTokenPos = makePos(startLine, startCol);
+			return t;
+		}
+		if (isDigit(ch)) {
+			var t = readNumber();
+			lastTokenPos = makePos(startLine, startCol);
+			return t;
+		}
+		if (isAlpha(ch)) {
+			var t = readIdentifier();
+			lastTokenPos = makePos(startLine, startCol);
+			return t;
+		}
 
 		advance();
 
 		switch (ch) {
 			case "+":
+				lastTokenPos = makePos(startLine, startCol);
 				return TPlus;
 			case "-":
+				lastTokenPos = makePos(startLine, startCol);
 				return TMinus;
 			case "*":
+				lastTokenPos = makePos(startLine, startCol);
 				return TMul;
 			case "/":
+				lastTokenPos = makePos(startLine, startCol);
 				return TDiv;
 			case "%":
+				lastTokenPos = makePos(startLine, startCol);
 				return TMod;
 
 			case "=":
 				if (peek() == "=") {
 					advance();
+					lastTokenPos = makePos(startLine, startCol);
 					return TEqualEqual;
 				}
+				lastTokenPos = makePos(startLine, startCol);
 				return TEqual;
 
 			case "!":
@@ -335,34 +368,56 @@ class Lexer {
 			case "<":
 				if (peek() == "=") {
 					advance();
+					lastTokenPos = makePos(startLine, startCol);
 					return TLessEqual;
 				}
+				lastTokenPos = makePos(startLine, startCol);
 				return TLess;
 
 			case ">":
 				if (peek() == "=") {
 					advance();
+					lastTokenPos = makePos(startLine, startCol);
 					return TGreaterEqual;
 				}
+				lastTokenPos = makePos(startLine, startCol);
 				return TGreater;
 
 			case "(":
+				lastTokenPos = makePos(startLine, startCol);
 				return TLParen;
 			case ")":
+				lastTokenPos = makePos(startLine, startCol);
 				return TRParen;
 			case "[":
+				lastTokenPos = makePos(startLine, startCol);
 				return TLBracket;
 			case "]":
+				lastTokenPos = makePos(startLine, startCol);
 				return TRBracket;
 			case ",":
+				lastTokenPos = makePos(startLine, startCol);
 				return TComma;
 			case ".":
+				lastTokenPos = makePos(startLine, startCol);
 				return TDot;
 			case ":":
+				lastTokenPos = makePos(startLine, startCol);
 				return TColon;
 
 			default:
 				throw new Error(SyntaxError("unexpected character: " + ch), line, col);
 		}
 	}
+
+	private inline function makePos(startLine:Int, startCol:Int):TokenPos {
+		return {line: startLine, col: startCol, colStart: startCol, colEnd: col - 1};
+	}
+}
+
+typedef TokenPos = {
+	var line:Int;
+	var col:Int;
+	var colStart:Int;
+	var colEnd:Int;
 }

--- a/paopao/hython/Parser.hx
+++ b/paopao/hython/Parser.hx
@@ -6,10 +6,12 @@ import paopao.hython.Lexer;
 
 class Parser {
 	public var tokens:Array<Token>;
+	public var tokenPositions:Array<TokenPos>;
 	public var pos:Int;
 
-	public function new(tokens:Array<Token>) {
+	public function new(tokens:Array<Token>, ?tokenPositions:Array<TokenPos>) {
 		this.tokens = tokens;
+		this.tokenPositions = tokenPositions != null ? tokenPositions : [];
 		this.pos = 0;
 	}
 
@@ -64,6 +66,8 @@ class Parser {
 			case TWhile: parseWhile();
 			case TDef: parseFunction();
 			case TReturn: parseReturn();
+			case TBreak: parseBreak();
+			case TContinue: parseContinue();
 			default: parseSimpleStmt();
 		};
 	}
@@ -73,18 +77,29 @@ class Parser {
 
 		if (match(TEqual)) {
 			var value = parseExpr();
-			return SAssign([expr], value);
+			return markStmt(SAssign([expr], value), posForExpr(expr));
 		}
 
-		return SExpr(expr);
+		return markStmt(SExpr(expr), posForExpr(expr));
 	}
 
 	private function parseReturn():Stmt {
 		advance();
+		var returnPos = lastPos();
 		if (Type.enumEq(peek(), TNewline)) {
-			return SReturn(null);
+			return markStmt(SReturn(null), returnPos);
 		}
-		return SReturn(parseExpr());
+		return markStmt(SReturn(parseExpr()), returnPos);
+	}
+
+	private function parseBreak():Stmt {
+		advance();
+		return markStmt(SBreak, lastPos());
+	}
+
+	private function parseContinue():Stmt {
+		advance();
+		return markStmt(SContinue, lastPos());
 	}
 
 	private function parseIf():Stmt {
@@ -100,7 +115,7 @@ class Parser {
 			orelse = parseBlock();
 		}
 
-		return SIf(test, body, orelse);
+		return markStmt(SIf(test, body, orelse), posForExpr(test));
 	}
 
 	private function parseWhile():Stmt {
@@ -109,10 +124,11 @@ class Parser {
 		expect(TColon);
 
 		var body = parseBlock();
-		return SWhile(test, body, []);
+		return markStmt(SWhile(test, body, []), posForExpr(test));
 	}
 
 	private function parseFunction():Stmt {
+		var startPos = pos;
 		advance(); // def
 
 		var name = switch (advance()) {
@@ -127,7 +143,7 @@ class Parser {
 
 		var body = parseBlock();
 
-		return SFunctionDef(name, args, body, null, false);
+		return markStmt(SFunctionDef(name, args, body, null, false), tokenPos(startPos));
 	}
 
 	private function parseArgs():Arguments {
@@ -191,7 +207,7 @@ class Parser {
 
 			var right = parseBinary(prec + 1);
 
-			left = EBinOp(left, mapOp(op), right);
+			left = markExpr(EBinOp(left, mapOp(op), right), posForExpr(left));
 		}
 
 		return left;
@@ -209,11 +225,12 @@ class Parser {
 	}
 
 	private function parsePrimary():Expr {
+		var tokenStart = pos;
 		var expr:Expr = switch (advance()) {
-			case TInt(v): EConstant(CInt(v));
-			case TFloat(v): EConstant(CFloat(v));
-			case TString(v): EConstant(CString(v));
-			case TIdent(name): EName(name);
+			case TInt(v): markExpr(EConstant(CInt(v)), tokenPos(tokenStart));
+			case TFloat(v): markExpr(EConstant(CFloat(v)), tokenPos(tokenStart));
+			case TString(v): markExpr(EConstant(CString(v)), tokenPos(tokenStart));
+			case TIdent(name): markExpr(EName(name), tokenPos(tokenStart));
 
 			case TLParen:
 				var e = parseExpr();
@@ -241,7 +258,7 @@ class Parser {
 					}
 
 					expect(TRParen);
-					expr = ECall(expr, args);
+					expr = markExpr(ECall(expr, args), posForExpr(expr));
 
 				case TDot:
 					advance();
@@ -249,17 +266,42 @@ class Parser {
 						case TIdent(id): id;
 						default: throw new Error(SyntaxError("Expected attribute"), 0, 0);
 					};
-					expr = EAttribute(expr, name);
+					expr = markExpr(EAttribute(expr, name), posForExpr(expr));
 
 				case TLBracket:
 					advance();
 					var index = parseExpr();
 					expect(TRBracket);
-					expr = ESubscript(expr, index);
+					expr = markExpr(ESubscript(expr, index), posForExpr(expr));
 
 				default:
 					return expr;
 			}
 		}
+	}
+
+	private inline function tokenPos(index:Int):SourcePos {
+		if (index >= 0 && index < tokenPositions.length) {
+			var p = tokenPositions[index];
+			return {line: p.line, col: p.col, colStart: p.colStart, colEnd: p.colEnd};
+		}
+		return {line: 0, col: 0, colStart: 0, colEnd: 0};
+	}
+
+	private inline function lastPos():SourcePos {
+		return tokenPos(pos - 1);
+	}
+
+	private inline function markStmt(stmt:Stmt, position:SourcePos):Stmt {
+		return NodeMeta.setStmtPos(stmt, position);
+	}
+
+	private inline function markExpr(expr:Expr, position:SourcePos):Expr {
+		return NodeMeta.setExprPos(expr, position);
+	}
+
+	private inline function posForExpr(expr:Expr):SourcePos {
+		var p = NodeMeta.getExprPos(expr);
+		return p != null ? p : {line: 0, col: 0, colStart: 0, colEnd: 0};
 	}
 }

--- a/paopao/hython/Semantic.hx
+++ b/paopao/hython/Semantic.hx
@@ -31,11 +31,13 @@ class Semantic {
 	private var currentScope:Scope;
 	private var inLoop:Int = 0;
 	private var inFunction:Int = 0;
+	private var filename:String = "<unknown>";
 
 	public function new() {}
 
 	// Entry
-	public function analyze(module:Module):Void {
+	public function analyze(module:Module, ?filename:String):Void {
+		this.filename = filename != null ? filename : "<unknown>";
 		currentScope = new Scope(null);
 
 		for (stmt in module.body) {
@@ -59,7 +61,7 @@ class Semantic {
 
 			case SReturn(value):
 				if (inFunction == 0) {
-					throw new Error(SyntaxError("return outside function"), 0, 0);
+					semanticError(stmt, SyntaxError("return outside function"));
 				}
 				if (value != null) visitExpr(value);
 
@@ -83,12 +85,12 @@ class Semantic {
 
 			case SBreak:
 				if (inLoop == 0) {
-					throw new Error(SyntaxError("break outside loop"), 0, 0);
+					semanticError(stmt, SyntaxError("break outside loop"));
 				}
 
 			case SContinue:
 				if (inLoop == 0) {
-					throw new Error(SyntaxError("continue outside loop"), 0, 0);
+					semanticError(stmt, SyntaxError("continue outside loop"));
 				}
 
 			case SFunctionDef(name, args, body, _, _):
@@ -169,7 +171,7 @@ class Semantic {
 
 			case EName(name):
 				if (!currentScope.exists(name)) {
-					throw new Error(SyntaxError("undefined variable: " + name), 0, 0);
+					semanticError(expr, SyntaxError("undefined variable: " + name));
 				}
 
 			case EConstant(_):
@@ -249,7 +251,26 @@ class Semantic {
 				visitExpr(slice);
 
 			default:
-				throw new Error(SyntaxError("invalid assignment target"), 0, 0);
+				semanticError(expr, SyntaxError("invalid assignment target"));
 		}
+	}
+
+	private function semanticError(node:Dynamic, errorDef:ErrorDef):Void {
+		var pos = extractNodePos(node);
+		var span:Null<Span> = null;
+		if (pos.colStart != null && pos.colEnd != null) {
+			span = {colStart: pos.colStart, colEnd: pos.colEnd};
+		}
+		throw new Error(errorDef, pos.line, pos.col, filename, span);
+	}
+
+	private function extractNodePos(node:Dynamic):SourcePos {
+		var stmtPos = NodeMeta.getStmtPos(cast node);
+		if (stmtPos != null) return stmtPos;
+
+		var exprPos = NodeMeta.getExprPos(cast node);
+		if (exprPos != null) return exprPos;
+
+		return {line: 0, col: 0, colStart: 0, colEnd: 0};
 	}
 }

--- a/paopao/hython/VM.hx
+++ b/paopao/hython/VM.hx
@@ -1061,9 +1061,10 @@ class VM {
 private inline function pass() {}
 
 	public static function runFromSource(source:String):String {
-		var ast = new Lexer(source).tokenize();
-		var code = new Parser(ast).parse();
-		new Semantic().analyze(code);
+		var lexer = new Lexer(source);
+		var ast = lexer.tokenize();
+		var code = new Parser(ast, lexer.tokenPositions).parse();
+		new Semantic().analyze(code, "<module>");
 		var bytes = new Compiler().compile(code);
 		var vm = new VM();
 		var result = vm.execute(bytes);

--- a/tests/TestMain.hx
+++ b/tests/TestMain.hx
@@ -1,12 +1,14 @@
 package;
 
 import tests.unit.TestRunner;
+import tests.unit.SemanticErrorPositionTest;
 import tests.unit.VMArithmeticTest;
 
 class TestMain {
 	static function main() {
 		var runner = new TestRunner();
 		runner.add(new VMArithmeticTest());
+		runner.add(new SemanticErrorPositionTest());
 
 		if (!runner.run()) {
 			Sys.exit(1);

--- a/tests/unit/SemanticErrorPositionTest.hx
+++ b/tests/unit/SemanticErrorPositionTest.hx
@@ -1,0 +1,52 @@
+package tests.unit;
+
+import paopao.hython.Error;
+import paopao.hython.Lexer;
+import paopao.hython.Parser;
+import paopao.hython.Semantic;
+
+class SemanticErrorPositionTest extends TestCase {
+	public function new() {
+		super();
+	}
+
+	public function testUndefinedVariableIncludesSourcePosition():Void {
+		var error = runSemanticExpectError("unknown_name\n", "undefined variable: unknown_name");
+		assertTrue(error.line > 0, "line should be non-zero");
+		assertTrue(error.col > 0, "col should be non-zero");
+	}
+
+	public function testReturnOutsideFunctionIncludesSourcePosition():Void {
+		var error = runSemanticExpectError("return 1\n", "return outside function");
+		assertTrue(error.line > 0, "line should be non-zero");
+		assertTrue(error.col > 0, "col should be non-zero");
+	}
+
+	public function testBreakOutsideLoopIncludesSourcePosition():Void {
+		var error = runSemanticExpectError("break\n", "break outside loop");
+		assertTrue(error.line > 0, "line should be non-zero");
+		assertTrue(error.col > 0, "col should be non-zero");
+	}
+
+	public function testContinueOutsideLoopIncludesSourcePosition():Void {
+		var error = runSemanticExpectError("continue\n", "continue outside loop");
+		assertTrue(error.line > 0, "line should be non-zero");
+		assertTrue(error.col > 0, "col should be non-zero");
+	}
+
+	private function runSemanticExpectError(source:String, expectedMessage:String):Error {
+		var lexer = new Lexer(source);
+		var tokens = lexer.tokenize();
+		var program = new Parser(tokens, lexer.tokenPositions).parse();
+
+		try {
+			new Semantic().analyze(program, "semantic_test.py");
+			fail("Expected semantic error");
+		} catch (e:Error) {
+			assertEquals(expectedMessage, e.errorMessage());
+			return e;
+		}
+
+		throw "unreachable";
+	}
+}

--- a/tests/unit/VMArithmeticTest.hx
+++ b/tests/unit/VMArithmeticTest.hx
@@ -39,9 +39,10 @@ class VMArithmeticTest extends TestCase {
 
 	private function executeSource(source:String):VM {
 		var vm = new VM();
-		var tokens = new Lexer(source).tokenize();
-		var program = new Parser(tokens).parse();
-		new Semantic().analyze(program);
+		var lexer = new Lexer(source);
+		var tokens = lexer.tokenize();
+		var program = new Parser(tokens, lexer.tokenPositions).parse();
+		new Semantic().analyze(program, "<test>");
 		var code = new Compiler().compile(program);
 		vm.execute(code);
 		return vm;


### PR DESCRIPTION
### Motivation
- Improve semantic error reporting by attaching source location (line/col/span) to AST nodes so semantic errors point to the triggering source site. 
- Ensure the module filename is propagated into semantic errors to produce meaningful `Error` instances for tracebacks and tests.

### Description
- Introduced `SourcePos` and `NodeMeta` maps in `paopao/hython/Ast.hx` to store statement/expression positions keyed by node identity without changing enum signatures (`SourcePos`, `NodeMeta.setStmtPos`, `NodeMeta.setExprPos`).
- Extended `paopao/hython/Lexer.hx` to track per-token positions via `tokenPositions` and `lastTokenPos`, and to emit positions for `TIndent`/`TDedent` and other tokens (`TokenPos` typedef and `makePos`).
- Updated `paopao/hython/Parser.hx` to accept optional `tokenPositions` (`new(tokens, ?tokenPositions)`), compute token start positions, and attach positions to key nodes using `markStmt`/`markExpr` for nodes such as `SReturn`, `SBreak`, `SContinue`, `SAssign`, `EName`, postfix expressions, and binary ops used as assignment targets.
- Added `semanticError(node, errorDef)` helper and node-position extraction in `paopao/hython/Semantic.hx`, replaced hard-coded `throw new Error(..., 0, 0)` call sites to emit `Error` with actual `line`, `col`, optional `span`, and the plumbed `filename`; preserved backward compatibility for `analyze(module, ?filename)`.
- Threaded filename and token positions through runtime/test entry points by updating `paopao/hython/VM.hx` and test helpers to pass `lexer.tokenPositions` into `Parser` and `filename` into `Semantic.analyze`.
- Added unit tests `tests/unit/SemanticErrorPositionTest.hx` and registered it in `tests/TestMain.hx`; updated `tests/unit/VMArithmeticTest.hx` to use the new parser/semantic call signatures.

### Testing
- Added unit tests under `tests/unit/` (`SemanticErrorPositionTest.hx`) that assert semantic failures include non-zero `line`/`col` and the expected message for undefined variable, `return` outside function, and `break`/`continue` outside loop, but these tests were not executed here due to environment constraints.
- Attempted to run the test suite with `haxe test.hxml` but it failed in this environment because `haxe` is not installed (`/bin/bash: line 1: haxe: command not found`).
- Ran repository checks including `git diff --check` and a search to confirm there are no remaining `throw new Error(..., 0, 0)` semantic sites; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed67610edc832abd2544b2cb763cfe)