### PR TITLE
Fix semantic resolution for native VM bindings

### DIFF
--- a/paopao/hython/Semantic.hx
+++ b/paopao/hython/Semantic.hx
@@ -28,6 +28,19 @@ class Scope {
 // Semantic Analyzer
 
 class Semantic {
+	private static final DEFAULT_PREDEFINED_NAMES:Array<String> = [
+		"len",
+		"print",
+		"range",
+		"type",
+		"int",
+		"str",
+		"bool",
+		"list",
+		"tuple",
+		"dict"
+	];
+
 	private var currentScope:Scope;
 	private var inLoop:Int = 0;
 	private var inFunction:Int = 0;
@@ -36,9 +49,17 @@ class Semantic {
 	public function new() {}
 
 	// Entry
-	public function analyze(module:Module, ?filename:String):Void {
+	public function analyze(module:Module, ?filename:String, ?predefinedNames:Array<String>):Void {
 		this.filename = filename != null ? filename : "<unknown>";
 		currentScope = new Scope(null);
+		for (name in DEFAULT_PREDEFINED_NAMES) {
+			currentScope.define(name);
+		}
+		if (predefinedNames != null) {
+			for (name in predefinedNames) {
+				currentScope.define(name);
+			}
+		}
 
 		for (stmt in module.body) {
 			visitStmt(stmt);

--- a/paopao/hython/VM.hx
+++ b/paopao/hython/VM.hx
@@ -873,6 +873,22 @@ class VM {
 		globals.set(name, toValue(value));
 	}
 
+	public function getSemanticBindings():Array<String> {
+		var names:Array<String> = [];
+
+		for (name in globals.keys()) {
+			names.push(name);
+		}
+
+		for (name in builtins.keys()) {
+			if (names.indexOf(name) == -1) {
+				names.push(name);
+			}
+		}
+
+		return names;
+	}
+
 	private function pushFrame(code:CodeObject, parentLocals:Map<String, Value>):Void {
 		var newFrame:Frame = {
 			code: code,

--- a/tests/tests/TestHaxeNative.hx
+++ b/tests/tests/TestHaxeNative.hx
@@ -60,7 +60,7 @@ result = t.add(5)
 		var lexer = new Lexer(source);
 		var tokens = lexer.tokenize();
 		var program = new Parser(tokens, lexer.tokenPositions).parse();
-		new Semantic().analyze(program, "<test>");
+		new Semantic().analyze(program, "<test>", vm.getSemanticBindings());
 		var code = new Compiler().compile(program);
 		vm.execute(code);
 	}


### PR DESCRIPTION
### Motivation
- The semantic analyzer reported `undefined variable: add` for tests that inject native functions/classes at runtime because those names were not visible to static analysis. 
- The intent is to let the analyzer know about VM-provided symbols (builtins and runtime globals) so test and embedding flows that inject native bindings pass semantic checks.

### Description
- Add `DEFAULT_PREDEFINED_NAMES` in `Semantic` and pre-seed the root scope with common builtin names (e.g. `len`, `print`, `range`, `type`, `int`, `str`, `bool`, `list`, `tuple`, `dict`).
- Extend `Semantic.analyze(...)` with an optional `predefinedNames:Array<String>` parameter and register those names in the initial scope before visiting statements.
- Add `VM.getSemanticBindings()` to return an array of VM-visible names (globals + builtins) for use by the analyzer.
- Update `tests/tests/TestHaxeNative.hx` to call `new Semantic().analyze(program, "<test>", vm.getSemanticBindings())` so host-injected names are treated as defined.

### Testing
- Attempted to run the test suite with `haxe test.hxml` but the `haxe` tool is not available in this environment (`haxe: command not found`), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee42a60990832ab1af3faac5e06997)