### PR TITLE
Add parsing support for 'for' loops and a VM test for for-in range

### DIFF
--- a/paopao/hython/Parser.hx
+++ b/paopao/hython/Parser.hx
@@ -64,6 +64,7 @@ class Parser {
 		return switch (peek()) {
 			case TIf: parseIf();
 			case TWhile: parseWhile();
+			case TFor: parseFor();
 			case TDef: parseFunction();
 			case TReturn: parseReturn();
 			case TBreak: parseBreak();
@@ -125,6 +126,25 @@ class Parser {
 
 		var body = parseBlock();
 		return markStmt(SWhile(test, body, []), posForExpr(test));
+	}
+
+
+	private function parseFor():Stmt {
+		advance(); // for
+		var target = parseExpr();
+		expect(TIn);
+		var iter = parseExpr();
+		expect(TColon);
+
+		var body = parseBlock();
+		var orelse:Array<Stmt> = [];
+
+		if (match(TElse)) {
+			expect(TColon);
+			orelse = parseBlock();
+		}
+
+		return markStmt(SFor(target, iter, body, orelse, false), posForExpr(target));
 	}
 
 	private function parseFunction():Stmt {

--- a/tests/tests/VMArithmeticTest.hx
+++ b/tests/tests/VMArithmeticTest.hx
@@ -33,6 +33,15 @@ class VMArithmeticTest extends TestCase {
 		assertEquals(3.5, vm.toHaxe(vm.getGlobal("result")));
 	}
 
+
+	public function testForInRangeAccumulatesValues():Void {
+		var vm = executeSource("result = 0
+for i in range(5):
+    result = result + i
+");
+		assertEquals(10, vm.toHaxe(vm.getGlobal("result")));
+	}
+
 	private function executeSource(source:String):VM {
 		var vm = new VM();
 		var lexer = new Lexer(source);


### PR DESCRIPTION
### Motivation
- Enable parsing of Python-style `for` loops so scripts using `for ... in ...:` can be compiled and executed.
- Add a regression test to verify that `for` loops over `range()` accumulate values correctly in the VM.

### Description
- Added a `parseFor` function and wired it into the `parseStmt` dispatch so `case TFor` now calls `parseFor`.
- `parseFor` consumes `for`, parses the target, the `in` expression, the trailing `:`, the block body, and an optional `else` block, and returns an `SFor` node with position info via `posForExpr`.
- Added `testForInRangeAccumulatesValues` in `VMArithmeticTest` which executes a small script using `for i in range(5):` to accumulate and assert the expected result.

### Testing
- Ran the project unit tests including `VMArithmeticTest` and the new `testForInRangeAccumulatesValues` test, and they passed.
- Executed the parser+compiler+VM flow via the existing `executeSource` helper to validate the new `for` parsing path at runtime, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3dce89b0832aa4cb7ba766e3c1ea)