### PR TITLE
Add comparison operators and chained-comparison parsing; add VM tests

### DIFF
--- a/paopao/hython/Parser.hx
+++ b/paopao/hython/Parser.hx
@@ -207,6 +207,7 @@ class Parser {
 
 	private function getPrecedence(op:Token):Int {
 		return switch (op) {
+			case TEqualEqual | TNotEqual | TLess | TGreater | TLessEqual | TGreaterEqual: 5;
 			case TPlus | TMinus: 10;
 			case TMul | TDiv: 20;
 			default: -1;
@@ -227,10 +228,34 @@ class Parser {
 
 			var right = parseBinary(prec + 1);
 
+			if (isComparisonToken(op)) {
+				var chainStart = posForExpr(left);
+				var chain = markExpr(EBinOp(left, mapOp(op), right), chainStart);
+				var previousRight = right;
+
+				while (isComparisonToken(peek())) {
+					var chainedOp = advance();
+					var chainedRight = parseBinary(prec + 1);
+					var comparison = markExpr(EBinOp(previousRight, mapOp(chainedOp), chainedRight), posForExpr(previousRight));
+					chain = markExpr(EBinOp(chain, BinOp.And, comparison), chainStart);
+					previousRight = chainedRight;
+				}
+
+				left = chain;
+				continue;
+			}
+
 			left = markExpr(EBinOp(left, mapOp(op), right), posForExpr(left));
 		}
 
 		return left;
+	}
+
+	private inline function isComparisonToken(t:Token):Bool {
+		return switch (t) {
+			case TEqualEqual | TNotEqual | TLess | TGreater | TLessEqual | TGreaterEqual: true;
+			default: false;
+		};
 	}
 
 	private function mapOp(t:Token):BinOp {
@@ -239,6 +264,12 @@ class Parser {
 			case TMinus: BinOp.Sub;
 			case TMul: BinOp.Mult;
 			case TDiv: BinOp.Div;
+			case TEqualEqual: BinOp.Eq;
+			case TNotEqual: BinOp.NotEq;
+			case TLess: BinOp.Lt;
+			case TGreater: BinOp.Gt;
+			case TLessEqual: BinOp.LtE;
+			case TGreaterEqual: BinOp.GtE;
 			default:
 				throw new Error(SyntaxError("Unknown operator"), 0, 0);
 		};

--- a/tests/tests/VMArithmeticTest.hx
+++ b/tests/tests/VMArithmeticTest.hx
@@ -33,6 +33,37 @@ class VMArithmeticTest extends TestCase {
 		assertEquals(3.5, vm.toHaxe(vm.getGlobal("result")));
 	}
 
+	public function testComparisonOperatorsEvaluateCorrectly():Void {
+		var vm = executeSource("lt = 1 < 2
+gt = 2 > 1
+lte = 2 <= 2
+gte = 3 >= 2
+eq = 4 == 4
+neq = 4 != 5
+");
+		assertEquals(true, vm.toHaxe(vm.getGlobal("lt")));
+		assertEquals(true, vm.toHaxe(vm.getGlobal("gt")));
+		assertEquals(true, vm.toHaxe(vm.getGlobal("lte")));
+		assertEquals(true, vm.toHaxe(vm.getGlobal("gte")));
+		assertEquals(true, vm.toHaxe(vm.getGlobal("eq")));
+		assertEquals(true, vm.toHaxe(vm.getGlobal("neq")));
+	}
+
+	public function testComparisonPrecedenceIsLowerThanArithmetic():Void {
+		var vm = executeSource("result = 1 + 2 <= 3");
+		assertEquals(true, vm.toHaxe(vm.getGlobal("result")));
+	}
+
+	public function testChainedComparisonTrue():Void {
+		var vm = executeSource("result = 1 < 2 < 3");
+		assertEquals(true, vm.toHaxe(vm.getGlobal("result")));
+	}
+
+	public function testChainedComparisonFalse():Void {
+		var vm = executeSource("result = 1 < 2 > 3");
+		assertEquals(false, vm.toHaxe(vm.getGlobal("result")));
+	}
+
 
 	public function testForInRangeAccumulatesValues():Void {
 		var vm = executeSource("result = 0


### PR DESCRIPTION
### Motivation

- Add parsing and AST mapping for comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`) so they can be used in expressions. 
- Support Python-style chained comparisons (e.g. `1 < 2 < 3`) and ensure comparison precedence is lower than arithmetic.

### Description

- Added comparison precedence in `getPrecedence` and an `isComparisonToken` helper to identify comparison tokens in `Parser.hx`.
- Extended `mapOp` to map comparison tokens to `BinOp` variants (`Eq`, `NotEq`, `Lt`, `Gt`, `LtE`, `GtE`).
- Enhanced `parseBinary` to recognize comparison operators and build chained comparisons by creating individual comparison expressions and combining them with `BinOp.And` to represent `a < b < c` semantics.
- Added unit tests in `tests/tests/VMArithmeticTest.hx` covering evaluation of comparisons, precedence relative to arithmetic, and chained-comparison true/false cases.

### Testing

- Ran the unit test suite including the new tests in `tests/tests/VMArithmeticTest.hx` such as `testComparisonOperatorsEvaluateCorrectly`, `testComparisonPrecedenceIsLowerThanArithmetic`, `testChainedComparisonTrue`, and `testChainedComparisonFalse`.
- All executed automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef46720b54832a8358ec084d748c5c)