### PR TITLE
Lower C++ recursion guard depth to avoid process stack overflow

### DIFF
--- a/paopao/hython/VM.hx
+++ b/paopao/hython/VM.hx
@@ -111,7 +111,9 @@ class VM {
 		this.frames = [];
 		this.blockStack = [];
 		this.builtins = new StringMap();
-		this.maxCallDepth = 1000;
+		// Keep the recursion guard conservative on C++ targets to avoid
+		// exhausting the native call stack before the VM can raise RecursionError.
+		this.maxCallDepth = #if cpp 256 #else 1000 #end;
 
 		initBuiltins();
 	}


### PR DESCRIPTION
### Motivation
- The Windows C++ test run showed all unit tests passing but the process exited with a stack overflow (`-1073741571` / `0xC00000FD`), so the VM should enforce a more conservative recursion limit on `cpp` targets to ensure the VM raises `RecursionError` before the host runtime stack is exhausted.

### Description
- Set `VM.maxCallDepth` using a Haxe compile-time conditional so `cpp` builds use `256` and other targets keep `1000`, and add a short comment explaining the rationale; change is in `paopao/hython/VM.hx`.

### Testing
- Ran the project test runner (`test.bat`) in the build environment which executed unit tests but the process exited with a stack overflow (`-1073741571`), motivating this change. 
- Attempted to run a local build with `haxe test.hxml` after the change, but the environment lacks `haxe` (`command not found`), so no compile/run validation could be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef617c082c832aa6ccf22fac9fe22b)