### PR TITLE
Add Python-style class support and RuleScript-style `parent` bridge (VObject)

### DIFF
--- a/paopao/hython/Interpreter.hx
+++ b/paopao/hython/Interpreter.hx
@@ -55,6 +55,10 @@ class Interpreter {
 
 	public var importEnabled:Bool = true;
 
+	/** Native Haxe owner exposed to scripts as the global `parent`, matching RuleScript-style embedding. */
+	public var parent(get, set):Dynamic;
+	var _parent:Dynamic = null;
+
 	public var curStmt(default, null):Null<Stmt> = null;
 
 	public function new(filename:String) {
@@ -62,6 +66,16 @@ class Interpreter {
 		this.globals = new StringMap<PyValue>();
 		this.frames = [globals];
 		this._functionDepth = 0;
+	}
+
+	function get_parent():Dynamic {
+		return _parent;
+	}
+
+	function set_parent(value:Dynamic):Dynamic {
+		_parent = value;
+		globals.set("parent", haxeToPyValue(value));
+		return value;
 	}
 
 	public function posInfos() {
@@ -178,6 +192,13 @@ class Interpreter {
 			case SClassDef(name, bases, classBody):
 				var methods = new StringMap<PyValue>();
 				var fields = new StringMap<PyValue>();
+				if (classBody.length > 0) {
+					switch (classBody[0]) {
+						case SExpr(EConstant(CString(doc))):
+							fields.set("__doc__", VString(doc));
+						default:
+					}
+				}
 				for (stmt in classBody) {
 					curStmt = stmt;
 					switch (stmt) {
@@ -470,15 +491,8 @@ class Interpreter {
 			return VDict(map);
 		}
 
-		if (Reflect.isFunction(value)) {
-			var params = new Vector<String>(0);
-			return VFunction(FNative("native", params, function(args:Vector<PyValue>):PyValue {
-				var haxeArgs:Array<Dynamic> = [];
-				for (arg in args)
-					haxeArgs.push(pyValueToHaxe(arg));
-				return haxeToPyValue(Reflect.callMethod(null, cast value, haxeArgs));
-			}));
-		}
+		if (Reflect.isFunction(value))
+			return haxeFunctionToPyFunction(value);
 
 		return switch (Type.typeof(value)) {
 			case TBool:
@@ -489,14 +503,21 @@ class Interpreter {
 				VFloat(cast value);
 			case TClass(String):
 				VString(cast value);
-			case TObject:
-				var map = new StringMap<PyValue>();
-				for (field in Reflect.fields(value))
-					map.set(field, haxeToPyValue(Reflect.field(value, field)));
-				VDict(map);
+			case TClass(_) | TObject:
+				VObject(value);
 			default:
 				throw new Error(TypeError("cannot convert Haxe value to PyValue: " + Std.string(value)), 0, 0, "<haxe>");
 		}
+	}
+
+	private static function haxeFunctionToPyFunction(value:Dynamic):PyValue {
+		var params = new Vector<String>(0);
+		return VFunction(FNative("native", params, function(args:Vector<PyValue>):PyValue {
+			var haxeArgs:Array<Dynamic> = [];
+			for (arg in args)
+				haxeArgs.push(pyValueToHaxe(arg));
+			return haxeToPyValue(Reflect.callMethod(null, cast value, haxeArgs));
+		}));
 	}
 
 	public static function pyValueToHaxe(value:PyValue):Dynamic {
@@ -528,22 +549,46 @@ class Interpreter {
 						pyArgs[i] = haxeToPyValue(args[i]);
 					return pyValueToHaxe(onCall(pyArgs));
 				});
+			case VObject(value):
+				value;
 			case VFunction(_) | VClass(_) | VInstance(_):
 				value;
 		}
 	}
 
 	private function instantiateClass(classDef:PyClass, args:Array<PyValue>):PyValue {
+		var fields = collectClassFields(classDef);
+		var instance = VInstance(classDef, fields);
+		var init = findClassMethod(classDef, "__init__");
+		if (init != null)
+			callFunctionValue(init, [instance].concat(args), "__init__");
+		else if (args.length > 0)
+			throw new Error(TypeError(className(classDef) + "() expected 0 arguments, got " + args.length), 0, 0, filename);
+		return instance;
+	}
+
+	private function collectClassFields(classDef:PyClass):StringMap<PyValue> {
 		var fields = new StringMap<PyValue>();
 		switch (classDef) {
-			case FUser(_, _, _, classFields) | FNative(_, _, classFields):
-				for (key in classFields.keys()) {
-					var value = classFields.get(key);
-					if (value != null)
-						fields.set(key, value);
-				}
+			case FUser(_, bases, _, classFields):
+				for (base in bases)
+					switch (base) {
+						case VClass(baseDef): copyFields(fields, collectClassFields(baseDef));
+						default:
+					}
+				copyFields(fields, classFields);
+			case FNative(_, _, classFields):
+				copyFields(fields, classFields);
 		}
-		return VInstance(classDef, fields);
+		return fields;
+	}
+
+	private function copyFields(target:StringMap<PyValue>, source:StringMap<PyValue>):Void {
+		for (key in source.keys()) {
+			var value = source.get(key);
+			if (value != null)
+				target.set(key, value);
+		}
 	}
 
 	private function assignTarget(target:Expr, value:PyValue):Void {
@@ -570,6 +615,8 @@ class Interpreter {
 				switch (evalExpr(objectExpr)) {
 					case VInstance(_, fields):
 						fields.set(attr, value);
+					case VObject(object):
+						Reflect.setField(object, attr, pyValueToHaxe(value));
 					default:
 						runtimeError(AttributeError("can't set attribute"), target);
 				}
@@ -683,16 +730,99 @@ class Interpreter {
 	private function getAttribute(value:PyValue, attr:String, node:Expr):PyValue {
 		return switch (value) {
 			case VInstance(cls, fields):
-				if (fields.exists(attr)) fields.get(attr); else switch (cls) {
-					case FUser(_, _, methods, _) | FNative(_, methods, _):
-						if (methods.exists(attr)) methods.get(attr); else runtimeError(AttributeError("object has no attribute '" + attr + "'"), node);
+				if (fields.exists(attr)) {
+					fields.get(attr);
+				} else {
+					var method = findClassMethod(cls, attr);
+					method != null ? bindInstanceMethod(value, method) : runtimeError(AttributeError("object has no attribute '" + attr + "'"), node);
 				}
-			case VClass(FUser(_, _, methods, fields)) | VClass(FNative(_, methods, fields)):
-				if (fields.exists(attr)) fields.get(attr); else if (methods.exists(attr)) methods.get(attr); else
-					runtimeError(AttributeError("class has no attribute '"
-					+ attr + "'"), node);
+			case VClass(cls):
+				var field = findClassField(cls, attr);
+				if (field != null) field; else {
+					var method = findClassMethod(cls, attr);
+					method != null ? method : runtimeError(AttributeError("class has no attribute '" + attr + "'"), node);
+				}
+			case VObject(object):
+				var field = Reflect.field(object, attr);
+				if (field != null || Reflect.hasField(object, attr)) {
+					haxeToPyValue(field);
+				} else {
+					runtimeError(AttributeError("object has no attribute '" + attr + "'"), node);
+				}
 			default:
 				runtimeError(AttributeError("object has no attribute '" + attr + "'"), node);
+		}
+	}
+
+	private function findClassMethod(classDef:PyClass, name:String):Null<PyValue> {
+		return switch (classDef) {
+			case FUser(_, bases, methods, _):
+				if (methods.exists(name)) {
+					methods.get(name);
+				} else {
+					var found:Null<PyValue> = null;
+					for (base in bases) {
+						switch (base) {
+							case VClass(baseDef):
+								found = findClassMethod(baseDef, name);
+								if (found != null)
+									break;
+							default:
+						}
+					}
+					found;
+				}
+			case FNative(_, methods, _):
+				methods.exists(name) ? methods.get(name) : null;
+		}
+	}
+
+	private function findClassField(classDef:PyClass, name:String):Null<PyValue> {
+		return switch (classDef) {
+			case FUser(_, bases, _, fields):
+				if (fields.exists(name)) {
+					fields.get(name);
+				} else {
+					var found:Null<PyValue> = null;
+					for (base in bases) {
+						switch (base) {
+							case VClass(baseDef):
+								found = findClassField(baseDef, name);
+								if (found != null)
+									break;
+							default:
+						}
+					}
+					found;
+				}
+			case FNative(_, _, fields):
+				fields.exists(name) ? fields.get(name) : null;
+		}
+	}
+
+	private function bindInstanceMethod(instance:PyValue, method:PyValue):PyValue {
+		return switch (method) {
+			case VFunction(func):
+				VFunction(FNative("bound_method", new Vector<String>(0), function(args:Vector<PyValue>):PyValue {
+					return callFunction(func, [instance].concat([for (arg in args) arg]));
+				}));
+			default:
+				method;
+		}
+	}
+
+	private function callFunctionValue(value:PyValue, args:Array<PyValue>, name:String):PyValue {
+		return switch (value) {
+			case VFunction(func):
+				callFunction(func, args);
+			default:
+				throw new Error(TypeError(name + " is not callable"), 0, 0, filename);
+		}
+	}
+
+	private function className(classDef:PyClass):String {
+		return switch (classDef) {
+			case FUser(name, _, _, _) | FNative(name, _, _): name;
 		}
 	}
 

--- a/paopao/hython/Lexer.hx
+++ b/paopao/hython/Lexer.hx
@@ -57,6 +57,7 @@ enum Token {
 	TFor;
 	TIn;
 	TDef;
+	TClass;
 	TReturn;
 	TImport;
 	TFrom;
@@ -204,9 +205,27 @@ class Lexer {
 
 	private function readString(quote:String):Token {
 		var value = "";
-		advance();
+		var isTripleQuoted = peek(1) == quote && peek(2) == quote;
 
-		while (peek() != quote && peek() != HxString.fromCharCode(0)) {
+		advance();
+		if (isTripleQuoted) {
+			advance();
+			advance();
+		}
+
+		while (peek() != HxString.fromCharCode(0)) {
+			if (isTripleQuoted && peek() == quote && peek(1) == quote && peek(2) == quote) {
+				advance();
+				advance();
+				advance();
+				return TString(value);
+			}
+
+			if (!isTripleQuoted && peek() == quote) {
+				advance();
+				return TString(value);
+			}
+
 			if (peek() == "\\") {
 				advance();
 				var esc = advance();
@@ -225,9 +244,7 @@ class Lexer {
 			}
 		}
 
-		if (peek() == quote)
-			advance();
-		return TString(value);
+		throw new Error(SyntaxError("unterminated string literal"), line, col);
 	}
 
 	private function readNumber():Token {
@@ -261,6 +278,7 @@ class Lexer {
 			case "for": TFor;
 			case "in": TIn;
 			case "def": TDef;
+			case "class": TClass;
 			case "return": TReturn;
 			case "import": TImport;
 			case "from": TFrom;

--- a/paopao/hython/Parser.hx
+++ b/paopao/hython/Parser.hx
@@ -67,9 +67,11 @@ class Parser {
 			case TWhile: parseWhile();
 			case TFor: parseFor();
 			case TDef: parseFunction();
+			case TClass: parseClass();
 			case TReturn: parseReturn();
 			case TBreak: parseBreak();
 			case TContinue: parseContinue();
+			case TPass: parsePass();
 			case TImport: parseImport();
 			case TFrom: parseImportFrom();
 			default: parseSimpleStmt();
@@ -164,6 +166,11 @@ class Parser {
 		return markStmt(SContinue, lastPos());
 	}
 
+	private function parsePass():Stmt {
+		advance();
+		return markStmt(SPass, lastPos());
+	}
+
 	private function parseIf():Stmt {
 		advance(); // if
 		var test = parseExpr();
@@ -226,6 +233,29 @@ class Parser {
 		return markStmt(SFunctionDef(name, args, body, null, false), tokenPos(startPos));
 	}
 
+	private function parseClass():Stmt {
+		var startPos = pos;
+		advance(); // class
+
+		var name = switch (advance()) {
+			case TIdent(id): id;
+			default: throw new Error(SyntaxError("Expected class name"), 0, 0);
+		};
+
+		var bases:Array<Expr> = [];
+		if (match(TLParen)) {
+			while (!Type.enumEq(peek(), TRParen)) {
+				bases.push(parseExpr());
+				if (!match(TComma))
+					break;
+			}
+			expect(TRParen);
+		}
+
+		expect(TColon);
+		return markStmt(SClassDef(name, bases, parseBlock()), tokenPos(startPos));
+	}
+
 	private function parseArgs():Arguments {
 		var list:Array<Arg> = [];
 
@@ -268,14 +298,16 @@ class Parser {
 	private function getPrecedence(op:Token):Int {
 		return switch (op) {
 			case TEqualEqual | TNotEqual | TLess | TGreater | TLessEqual | TGreaterEqual: 5;
+			case TAnd: 2;
+			case TOr: 1;
 			case TPlus | TMinus: 10;
-			case TMul | TDiv: 20;
+			case TMul | TDiv | TMod: 20;
 			default: -1;
 		};
 	}
 
 	private function parseBinary(minPrec:Int):Expr {
-		var left = parsePrimary();
+		var left = parseUnary();
 
 		while (true) {
 			var op = peek();
@@ -318,12 +350,32 @@ class Parser {
 		};
 	}
 
+	private function parseUnary():Expr {
+		var tokenStart = pos;
+		return switch (peek()) {
+			case TPlus:
+				advance();
+				markExpr(EUnaryOp(UnaryOp.UAdd, parseUnary()), tokenPos(tokenStart));
+			case TMinus:
+				advance();
+				markExpr(EUnaryOp(UnaryOp.USub, parseUnary()), tokenPos(tokenStart));
+			case TNot:
+				advance();
+				markExpr(EUnaryOp(UnaryOp.Not, parseUnary()), tokenPos(tokenStart));
+			default:
+				parsePrimary();
+		}
+	}
+
 	private inline function mapOp(t:Token):BinOp {
 		return switch (t) {
 			case TPlus: BinOp.Add;
 			case TMinus: BinOp.Sub;
 			case TMul: BinOp.Mult;
 			case TDiv: BinOp.Div;
+			case TMod: BinOp.Mod;
+			case TAnd: BinOp.And;
+			case TOr: BinOp.Or;
 			case TEqualEqual: BinOp.Eq;
 			case TNotEqual: BinOp.NotEq;
 			case TLess: BinOp.Lt;
@@ -344,9 +396,24 @@ class Parser {
 			case TIdent(name): markExpr(EName(name), tokenPos(tokenStart));
 
 			case TLParen:
-				var e = parseExpr();
-				expect(TRParen);
-				e;
+				if (match(TRParen)) {
+					markExpr(ETuple([]), tokenPos(tokenStart));
+				} else {
+					var first = parseExpr();
+					if (match(TComma)) {
+						var items = [first];
+						while (!Type.enumEq(peek(), TRParen)) {
+							items.push(parseExpr());
+							if (!match(TComma))
+								break;
+						}
+						expect(TRParen);
+						markExpr(ETuple(items), tokenPos(tokenStart));
+					} else {
+						expect(TRParen);
+						first;
+					}
+				}
 
 			default:
 				throw new Error(SyntaxError("Unexpected token"), 0, 0);

--- a/paopao/hython/PyData.hx
+++ b/paopao/hython/PyData.hx
@@ -77,4 +77,5 @@ enum PyValue {
 	// Object-oriented
 	VClass(classDef:PyClass); // Class (type) object
 	VInstance(cls:PyClass, fields:StringMap<PyValue>); // Class instance
+	VObject(value:Dynamic); // Native Haxe object bridge
 }

--- a/tests/tests/Test1.hx
+++ b/tests/tests/Test1.hx
@@ -13,6 +13,17 @@ private class TestLibraryClass {
 	}
 }
 
+private class ParentHost {
+	public var saved:String = "";
+
+	public function new() {}
+
+	public function some_function(arg1:String, arg2:String):String {
+		saved = arg1 + ":" + arg2;
+		return saved;
+	}
+}
+
 class Test1 extends TestCase {
 	public function new() {
 		super();
@@ -199,12 +210,92 @@ def get_add():
 		assertEquals(9, callable(4, 5));
 	}
 
+	public function testPythonStyleClassesConstructInstances():Void {
+		var interpreter = new Interpreter("<test>");
+
+		interpreter.run("
+class MyClass:
+  \"\"\"A simple example class\"\"\"
+  i = 12345
+  def f(self):
+    return 'hello world'
+
+class Complex:
+  def __init__(self, realpart, imagpart):
+    self.r = realpart
+    self.i = imagpart
+
+x = Complex(3.0, -4.5)
+y = MyClass()
+result = (x.r, x.i)
+message = y.f()
+doc = MyClass.__doc__
+");
+
+		switch (interpreter.getGlobal("result")) {
+			case VTuple(items):
+				assertPyFloat(3.0, items[0]);
+				assertPyFloat(-4.5, items[1]);
+			default:
+				fail("expected tuple result");
+		}
+		assertPyString("hello world", interpreter.getGlobal("message"));
+		assertPyString("A simple example class", interpreter.getGlobal("doc"));
+	}
+
+	public function testClassInheritanceUsesBaseMethodsAndFields():Void {
+		var interpreter = new Interpreter("<test>");
+
+		interpreter.run("
+class Base1:
+  base_value = 7
+  def get_base(self):
+    return self.base_value
+
+class Base2:
+  def greet(self):
+    return 'hi'
+
+class DerivedClassName(Base1, Base2):
+  def get_own(self):
+    return self.greet()
+
+x = DerivedClassName()
+base_result = x.get_base()
+own_result = x.get_own()
+");
+
+		assertPyInt(7, interpreter.getGlobal("base_result"));
+		assertPyString("hi", interpreter.getGlobal("own_result"));
+	}
+
+	public function testParentObjectIsAvailableToScripts():Void {
+		var interpreter = new Interpreter("<test>");
+		var host = new ParentHost();
+		interpreter.parent = host;
+
+		interpreter.run("result = parent.some_function('hi', 'hello')
+");
+
+		assertEquals("hi:hello", host.saved);
+		assertPyString("hi:hello", interpreter.getGlobal("result"));
+	}
+
 	private function assertPyInt(expected:Int, actual:PyValue):Void {
 		switch (actual) {
 			case VInt(value):
 				assertEquals(expected, value);
 			default:
 				fail("expected VInt(" + expected + ") but got " + Std.string(actual));
+		}
+	}
+
+	private function assertPyFloat(expected:Float, actual:PyValue):Void {
+		switch (actual) {
+			case VFloat(value):
+				assertEquals(expected, value);
+			default:
+				fail("expected VFloat(" + expected + ") but got " + Std.string(actual));
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Expose a native Haxe owner object to scripts as a global `parent` (RuleScript-style) so host code can be called from scripts. 
- Add support for Python-style `class` declarations (fields, methods, `__init__`, docstrings and multiple inheritance) to make the interpreter able to run class-based scripts. 
- Improve parser/lexer to recognize class-related syntax and useful expression forms (tuples, unary ops, `%`, `and`/`or`, `pass`, and triple-quoted docstrings).

### Description
- Added an interpreter `parent` property with getter/setter that stores the Haxe owner and exposes it in script globals via `globals.set("parent", haxeToPyValue(value))` (`Interpreter.hx`).
- Introduced `VObject(value:Dynamic)` in `PyData.hx` and bridged Haxe objects so scripts can read/set fields and call methods on native objects (conversions in `haxeToPyValue` / `pyValueToHaxe`, attribute access and assignment handling in `Interpreter.hx`).
- Implemented runtime support for Python-style classes: class docstring extraction, class field collection with inheritance (`collectClassFields` / `copyFields`), instance creation that calls `__init__`, method lookup across bases, and binding of instance methods (`findClassMethod`, `findClassField`, `bindInstanceMethod`, `instantiateClass`) in `Interpreter.hx`.
- Extended parser and lexer to support `class` and `pass` statements, triple-quoted strings for docstrings, tuple literal parsing for `(x, y)`, unary operators and `and`/`or`/`%` operator mapping, and added corresponding tokens and grammar changes in `Lexer.hx` and `Parser.hx`.
- Added regression tests in `tests/tests/Test1.hx` covering class instantiation, docstrings, multiple inheritance, constructor behavior, tuple results, and the `parent` callback from scripts.

### Testing
- Ran `git diff --check` which passed locally after the changes. 
- Added unit tests to `tests/tests/Test1.hx` (new tests present in the repo), but running `haxe test.hxml` was blocked because `haxe` is not installed in the container. 
- Attempts to obtain a Haxe runtime (`npx --yes haxe --version`) and install via `apt-get` were blocked by network/registry (received `403 Forbidden`), so the test suite could not be executed in this environment. 
- Changes were committed (`Add Hython class and parent support`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206dc349f8832a839e25bc03e50ba6)